### PR TITLE
ignore .clang-format files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ srv_gen/
 # qcreator stuff
 CMakeLists.txt.user
 
+# Clang-format style files
+.clang-format
+
 srv/_*.py
 *.pcd
 *.pyc


### PR DESCRIPTION
Allows integration with our clang-format scheme.
