### PR TITLE
Three corrections

### DIFF
--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -232,8 +232,8 @@ namespace dynamixel {
                         if (dynamixel_max_speed_iterator != _dynamixel_max_speed.end()) {
                             dynamixel::StatusPacket<Protocol> status;
                             ROS_DEBUG_STREAM("Setting velocity limit of joint "
-                                << _servos[i]->id() << " to "
-                                << dynamixel_max_speed_iterator->second);
+                                << _dynamixel_map[_servos[i]->id()] << " to "
+                                << dynamixel_max_speed_iterator->second << " rad/s.");
                             _dynamixel_controller.send(_servos[i]->set_moving_speed_angle(dynamixel_max_speed_iterator->second));
                             _dynamixel_controller.recv(status);
                         }
@@ -354,7 +354,8 @@ namespace dynamixel {
                 }
 
                 ROS_DEBUG_STREAM("Setting position of joint "
-                    << _servos[i]->id() << " to " << goal_pos);
+                    << _dynamixel_map[_servos[i]->id()] << " to " << goal_pos
+                    << " rad.");
                 _dynamixel_controller.send(_servos[i]->reg_goal_position_angle(goal_pos));
                 _dynamixel_controller.recv(status);
             }

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -143,7 +143,7 @@ namespace dynamixel {
     {
         // vector of actuators we are looking for
         std::vector<typename Protocol::id_t> ids(_dynamixel_map.size());
-        using dm_iter_t = std::unordered_map<id_t, std::string>::iterator;
+        using dm_iter_t = typename std::unordered_map<id_t, std::string>::iterator;
         for (dm_iter_t dm_iter = _dynamixel_map.begin(); dm_iter != _dynamixel_map.end(); ++dm_iter) {
             ids.push_back(dm_iter->first);
         }

--- a/src/dynamixel_control_hw.cpp
+++ b/src/dynamixel_control_hw.cpp
@@ -33,7 +33,6 @@
 *********************************************************************/
 
 /* Original Author: Dave Coleman (https://github.com/davetcoleman/ros_control_boilerplate) */
-#include <sstream>
 #include <unordered_map>
 
 #include <dynamixel_control_hw/dynamixel_hardware_interface.hpp>

--- a/src/dynamixel_control_hw.cpp
+++ b/src/dynamixel_control_hw.cpp
@@ -89,8 +89,7 @@ int main(int argc, char** argv)
     nhParams.getParam("max_speed", max_speed_param);
     std::map<std::string, double>::iterator max_speed_param_i;
     for (max_speed_param_i = max_speed_param.begin(); max_speed_param_i != max_speed_param.end(); max_speed_param_i++) {
-        Protocol::id_t k;
-        std::istringstream(max_speed_param_i->first) >> k;
+        Protocol::id_t k = std::stoll(max_speed_param_i->first);
         dynamixel_max_speed_map[k] = max_speed_param_i->second;
     }
 
@@ -100,8 +99,7 @@ int main(int argc, char** argv)
     nhParams.getParam("hardware_corrections", map_corrections);
     std::map<std::string, double>::iterator map_cor_i;
     for (map_cor_i = map_corrections.begin(); map_cor_i != map_corrections.end(); map_cor_i++) {
-        Protocol::id_t k;
-        std::istringstream(map_cor_i->first) >> k;
+        Protocol::id_t k = std::stoll(map_cor_i->first);
         dynamixel_corrections[k] = map_cor_i->second;
     }
 


### PR DESCRIPTION
- proper interpretation of parameters (string to integer conversion)
- Missing `typename`
- actuator name in messages instead of servo ID