### PR TITLE
Add velocity control mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ srv_gen/
 *.dox
 *.wikidoc
 
+# vscode stuff
+.vscode
+
 # eclipse stuff
 .project
 .cproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 In reverse chronological order:
 
+- breaking change: the configuration parameter syntax has changed; see sample configuration files
 - velocity control mode integrated
 - replace c-style code with std::chrono for time-related code
 - replace std::map with std::unordered_map when possible (hypothetical performance gain)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 In reverse chronological order:
 
+- velocity control mode integrated
 - replace c-style code with std::chrono for time-related code
 - replace std::map with std::unordered_map when possible (hypothetical performance gain)
 - remove all dependencies to boost

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [ROS control][] is a framework to design software control loops in [ROS][] (Robot Operating System) where the controller code is decoupled from the actual hardware.
 
-This piece of software provides a hardware interface for ROS control. it's aim is to allow generic software controllers to control a set of Dynamixel actuators.
+This piece of software provides a hardware interface for ROS control. Its aim is to allow generic software controllers to control a set of Dynamixel actuators.
 
 We are using it for our robots and developing it for this purpose. Version 0.0.1 is clearly no final code but it works for the basic usage.
 
@@ -10,6 +10,7 @@ We are using it for our robots and developing it for this purpose. Version 0.0.1
 
 - simple, ROS-style control interface for your dynamixel-based robot
 - not specific to a given number or set of actuators
+- position and velocity control
 - works with both version of Dynamixel protocol (1 and 2)
 - uses radians uniformly over all Dynamixel models (no need to worry about ticks-to-angle conversion)
 - you can set an offset for each actuator's position
@@ -19,7 +20,7 @@ We are using it for our robots and developing it for this purpose. Version 0.0.1
 We are currently working on the following features:
 
 - joint limits not implemented yet
-- position control only (doesn't manage wheel mode)
+- add support for the more exotic control modes (including current and multi-turn)
 - it would be great to offer a service to reset one actuator after an overload error
 
 ## Installation and usage
@@ -37,7 +38,7 @@ If you want to use the sample launch files or to use one of the default controll
 - `ros-YourDistro-ros-controllers` and
 - `ros-YourDistro-joint-state-publisher`.
 
-Have a look at the `launch/sample.launch` file. It will by default launch two feed-forward only position controllers and a virtual controller that publishes the states of each actuator.
+Have a look at the `launch/sample.launch` file. It will by default launch two feed-forward only controllers (one position and one velocity) and a virtual controller that publishes the states of each actuator.
 
 *Before starting* it, check `config/sample.yaml` for the `hardware_mapping` section, the `serial_interface` and `baudrate` settings. Once you are sure that it's correct, you can launch the sample. By looking at the available topics, you should find two for the commands of each joint and one for the joint state.
 

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -16,22 +16,21 @@ dynamixel_control_hw:
   loop_frequency: 50
   cycle_time_error_threshold: 0.1
   baudrate: 1000000 # in bauds
-  dynamixel_timeout: 0.05 # in seconds
-  dynamixel_scanning: 0.05 # in seconds
-  # correspondance between hardware IDs of the actuators and their names in ROS
-  hardware_mapping:
-    first: 1
-    second: 26
-  # offset to be added, in ticks, to the position of an actuator
-  hardware_corrections:
-    "26": 45
-  # max joint speed, in rad/s
-  # it shoud NOT be used for actuators in velocity mode
-  max_speed:
-    "1": 0.1
-    "26": 0.1
-  # command mode for the joint, either position or velocity
-  command_interface:
-    "1": velocity
-    "26": position
+  read_timeout: 0.05 # in seconds
+  scan_timeout: 0.05 # in seconds
+  # Cofniguration of the servos
+  servos:
+    first:
+      # hardware ID of the actuator
+      id: 1
+      # offset to be added, in radians, to the position of an actuator
+      offset: 4.5
+      command_interface: velocity
+    second:
+      id: 26
+      # max joint speed, in rad/s
+      # it shoud NOT be used for actuators in velocity mode
+      max-speed: 4
+  # default mode
+  default_command_interface: position
 

--- a/config/sample.yaml
+++ b/config/sample.yaml
@@ -3,18 +3,18 @@ dynamixel_controllers:
     type: joint_state_controller/JointStateController
     publish_rate: 10
 
-  first_position_controller:
-    type: position_controllers/JointPositionController
+  velocity_controller:
+    type: velocity_controllers/JointVelocityController
     joint: first
 
-  second_position_controller:
+  position_controller:
     type: position_controllers/JointPositionController
     joint: second
 
 dynamixel_control_hw:
-  loop_frequency: 10
-  cycle_time_error_threshold: 0.2
   serial_interface: /dev/ttyUSB0
+  loop_frequency: 50
+  cycle_time_error_threshold: 0.1
   baudrate: 1000000 # in bauds
   dynamixel_timeout: 0.05 # in seconds
   dynamixel_scanning: 0.05 # in seconds
@@ -26,6 +26,12 @@ dynamixel_control_hw:
   hardware_corrections:
     "26": 45
   # max joint speed, in rad/s
+  # it shoud NOT be used for actuators in velocity mode
   max_speed:
     "1": 0.1
     "26": 0.1
+  # command mode for the joint, either position or velocity
+  command_interface:
+    "1": velocity
+    "26": position
+

--- a/config/traj.yaml
+++ b/config/traj.yaml
@@ -21,21 +21,22 @@ dynamixel_control_hw:
   loop_frequency: 50
   cycle_time_error_threshold: 0.1
   baudrate: 1000000 # in bauds
-  dynamixel_timeout: 0.05 # in seconds
-  dynamixel_scanning: 0.05 # in seconds
-  # correspondance between hardware IDs of the actuators and their names in ROS
-  hardware_mapping:
-    arm_joint_1: 1
-    arm_joint_2: 2
-  # offset to be added, in radians, to the position of an actuator
-  hardware_corrections:
-    "1": 3.14159265359
-    "2": 3.14159265359
-  # max joint speed, in rad/s
-  # it shoud NOT be used for actuators in velocity mode
-  max_speed:
-    "1": 0.1
-  # command mode for the joint, either position or velocity
-  command_interface:
-    "1": position
-    "2": velocity
+  read_timeout: 0.05 # in seconds
+  scan_timeout: 0.05 # in seconds
+  # Configuration of the servos
+  servos:
+    arm_joint_1:
+      # hardware ID of the actuator
+      id: 1
+      # offset to be added, in radians, to the position of an actuator
+      offset: 3.14159265359
+      # max joint speed, in rad/s
+      # it shoud NOT be used for actuators in velocity mode
+      max_speed: 0.1
+    arm_joint_2:
+      id: 2
+      offset: 3.14159265359
+      # command mode for the joint, either position or velocity
+      command_interface: velocity
+  # default mode
+  default_command_interface: position

--- a/config/traj.yaml
+++ b/config/traj.yaml
@@ -7,7 +7,10 @@ dynamixel_controllers:
     type: position_controllers/JointTrajectoryController
     joints:
       - arm_joint_1
-      - arm_joint_2
+
+  vel_controller:
+    type: velocity_controllers/JointVelocityController
+    joint: arm_joint_2
 
   # second_position_controller:
   #   type: position_controllers/JointPositionController
@@ -22,13 +25,17 @@ dynamixel_control_hw:
   dynamixel_scanning: 0.05 # in seconds
   # correspondance between hardware IDs of the actuators and their names in ROS
   hardware_mapping:
-    arm_joint_1: 2
-    arm_joint_2: 1
+    arm_joint_1: 1
+    arm_joint_2: 2
   # offset to be added, in radians, to the position of an actuator
   hardware_corrections:
     "1": 3.14159265359
     "2": 3.14159265359
   # max joint speed, in rad/s
+  # it shoud NOT be used for actuators in velocity mode
   max_speed:
     "1": 0.1
-    "2": 0.1
+  # command mode for the joint, either position or velocity
+  command_interface:
+    "1": position
+    "2": velocity

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -188,20 +188,19 @@ namespace dynamixel {
                         = _c_mode_map.find(id);
                     if (c_mode_map_i != _c_mode_map.end()) {
                         if (c_mode_map_i->second != hardware_mode) {
-                            ROS_ERROR_STREAM("the command interface declared "
+                            ROS_ERROR_STREAM("The command interface declared "
                                 << mode2str(c_mode_map_i->second)
                                 << " for joint " << dynamixel_iterator->second
                                 << " but is set to " << mode2str(hardware_mode)
-                                << " in hardware. Using the one from hardware.");
-                            _c_mode_map[id] = hardware_mode;
+                                << " in hardware. Disabling this joint.");
+                            _c_mode_map[id] = OperatingMode::unknown;
                         }
                     }
                     else {
-                        ROS_WARN_STREAM("the command interface was not defined "
+                        ROS_ERROR_STREAM("The command interface was not defined "
                             << "for joint " << dynamixel_iterator->second
-                            << " fallback to the hardware's mode: "
-                            << mode2str(hardware_mode));
-                        _c_mode_map[id] = hardware_mode;
+                            << ". Disabling this joint.");
+                        _c_mode_map[id] = OperatingMode::unknown;
                     }
 
                     // tell ros_control the in-memory address to change to set new
@@ -216,9 +215,11 @@ namespace dynamixel {
                     else if (OperatingMode::wheel == hardware_mode) {
                         _jnt_vel_interface.registerHandle(cmd_handle);
                     }
-                    else
+                    else if (OperatingMode::unknown != hardware_mode)
                         ROS_ERROR_STREAM("Servo " << id << " was not initialised "
-                                                  << "(operating mode not supported)");
+                                                  << "(operating mode "
+                                                  << mode2str(hardware_mode)
+                                                  << " is not supported)");
 
                     // enable torque output on the servo and set its configuration
                     // including max speed

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -215,15 +215,25 @@ namespace dynamixel {
                     else if (OperatingMode::wheel == hardware_mode) {
                         _jnt_vel_interface.registerHandle(cmd_handle);
                     }
-                    else if (OperatingMode::unknown != hardware_mode)
+                    else if (OperatingMode::unknown != hardware_mode) {
                         ROS_ERROR_STREAM("Servo " << id << " was not initialised "
                                                   << "(operating mode "
                                                   << mode2str(hardware_mode)
                                                   << " is not supported)");
+                        _c_mode_map[id] = OperatingMode::unknown;
+                    }
 
-                    // enable torque output on the servo and set its configuration
-                    // including max speed
-                    _enable_and_configure_servo(_servos[i], hardware_mode);
+                    // Enable servos that were properly configured
+                    if (OperatingMode::unknown != _c_mode_map[id]) {
+                        // enable torque output on the servo and set its configuration
+                        // including max speed
+                        _enable_and_configure_servo(_servos[i], hardware_mode);
+                    }
+                    else {
+                        // remove this servo
+                        _servos.erase(_servos.begin() + i);
+                        --i;
+                    }
                 }
                 else {
                     ROS_WARN_STREAM("Servo " << id << " was not initialised "

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -52,8 +52,8 @@ namespace dynamixel {
             const float& read_timeout,
             const float& scan_timeout,
             std::unordered_map<id_t, std::string> dynamixel_map,
-            std::unordered_map<id_t, double> dynamixel_max_speed,
             std::unordered_map<id_t, OperatingMode> dynamixel_c_mode_map,
+            std::unordered_map<id_t, double> dynamixel_max_speed,
             std::unordered_map<id_t, double> dynamixel_corrections)
             : _usb_serial_interface(usb_serial_interface),
               _baudrate(get_baudrate(baudrate)),

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -205,7 +205,8 @@ namespace dynamixel {
                     }
 
                     // tell ros_control the in-memory address to change to set new
-                    // position or velocity goal for the actuator
+                    // position or velocity goal for the actuator (depending on
+                    // hardware_mode)
                     hardware_interface::JointHandle cmd_handle(
                         _jnt_state_interface.getHandle(dynamixel_iterator->second),
                         &_joint_commands[i]);
@@ -424,6 +425,15 @@ namespace dynamixel {
                 << " declared to the hardware interface but could not be found");
         }
     }
+
+    /** Enable torque output for a joint and send it the relevant settings.
+
+        For now, these settings are only the speed limit.
+
+        @param servo the actuator concerned
+        @param mode operating mode of the actuator (e.g. position or velocity,
+            in dynamixel speech, joint, wheel, etc.)
+    **/
     template <class Protocol>
     void DynamixelHardwareInterface<Protocol>::_enable_and_configure_servo(dynamixel_servo servo, OperatingMode mode)
     {

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -238,6 +238,9 @@ namespace dynamixel {
                 else {
                     ROS_WARN_STREAM("Servo " << id << " was not initialised "
                                              << "(not found in the parameters)");
+                    // remove this servo
+                    _servos.erase(_servos.begin() + i);
+                    --i;
                 }
             }
 

--- a/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_control_hw/dynamixel_hardware_interface.hpp
@@ -451,7 +451,7 @@ namespace dynamixel {
                 if (OperatingMode::joint == mode) {
                     dynamixel::StatusPacket<Protocol> status;
                     ROS_DEBUG_STREAM("Setting velocity limit of servo "
-                        << _dynamixel_map[_servos[i]->id()] << " to "
+                        << _dynamixel_map[servo->id()] << " to "
                         << dynamixel_max_speed_iterator->second << " rad/s.");
                     _dynamixel_controller.send(
                         servo->set_moving_speed_angle(

--- a/launch/sample.launch
+++ b/launch/sample.launch
@@ -20,6 +20,6 @@
 
   <!-- Start a controller for our dummy robot -->
   <node name="controller" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="/dynamixel_controllers/first_position_controller /dynamixel_controllers/second_position_controller
+    output="screen" args="/dynamixel_controllers/velocity_controller /dynamixel_controllers/position_controller
     /dynamixel_controllers/joint_state_controller" />
 </launch>

--- a/launch/traj.launch
+++ b/launch/traj.launch
@@ -21,5 +21,5 @@
   <!-- Start a controller for our dummy robot -->
   <node name="controller" pkg="controller_manager" type="spawner" respawn="false"
     output="screen" args="/dynamixel_controllers/joint_state_controller
-      /dynamixel_controllers/traj_controller" />
+      /dynamixel_controllers/traj_controller /dynamixel_controllers/vel_controller" />
 </launch>

--- a/src/dynamixel_control_hw.cpp
+++ b/src/dynamixel_control_hw.cpp
@@ -149,6 +149,7 @@ int main(int argc, char** argv)
     }
     catch (XmlRpc::XmlRpcException& e) {
         ROS_FATAL_STREAM("Exception raised when parsing the configuration: " << e.getMessage());
+        return 1;
     }
 
     if (!got_all_params) {

--- a/src/dynamixel_control_hw.cpp
+++ b/src/dynamixel_control_hw.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
     }
 
     // Retrieve the map for command interface (ID: velocity/position)
-    std::unordered_map<long long int, dynamixel::OperatingMode> dynamixel_c_mode_map;
+    std::unordered_map<Protocol::id_t, dynamixel::OperatingMode> dynamixel_c_mode_map;
     std::map<std::string, std::string> c_mode_param; // temporary map, from parameter server
     got_all_params &= nhParams.getParam("command_interface", c_mode_param);
     std::map<std::string, std::string>::iterator c_mode_param_i;
@@ -157,8 +157,8 @@ int main(int argc, char** argv)
             dynamixel_timeout,
             dynamixel_scanning,
             dynamixel_map,
-            dynamixel_c_mode_map,
             dynamixel_max_speed_map,
+            dynamixel_c_mode_map,
             dynamixel_corrections);
     dynamixel_hw_interface->init();
 

--- a/src/dynamixel_control_hw.cpp
+++ b/src/dynamixel_control_hw.cpp
@@ -157,8 +157,8 @@ int main(int argc, char** argv)
             dynamixel_timeout,
             dynamixel_scanning,
             dynamixel_map,
-            dynamixel_max_speed_map,
             dynamixel_c_mode_map,
+            dynamixel_max_speed_map,
             dynamixel_corrections);
     dynamixel_hw_interface->init();
 

--- a/src/dynamixel_control_hw.cpp
+++ b/src/dynamixel_control_hw.cpp
@@ -148,7 +148,9 @@ int main(int argc, char** argv)
         }
     }
     catch (XmlRpc::XmlRpcException& e) {
-        ROS_FATAL_STREAM("Exception raised when parsing the configuration: " << e.getMessage());
+        ROS_FATAL_STREAM("Exception raised by XmlRpc while reading the "
+            << "configuration: " << e.getMessage() << ".\n"
+            << "Please check the configuration, particularly parameter types.");
         return 1;
     }
 


### PR DESCRIPTION
Here a new control mode is supported : sending commands to servos in velocity command mode (wheel in Robotis' jargon).

The mode is detected in the servos but we require that the user declares the desired control mode with a ros parameter, to be sure to detect wrong assumption on the current control mode of a servo.