### PR TITLE
Fix installation filename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,6 @@ install(TARGETS dynamixel_hw
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(FILES dynamixel_control_plugins.xml
+install(FILES dynamixel_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
Hi, when I ran ``catkin_make install``, it failed.

```bash
CMake Error at dynamixel_control_hw/cmake_install.cmake:71 (file):
  file INSTALL cannot find
  "/tmp/ws/src/dynamixel_control_hw/dynamixel_control_plugins.xml".
Call Stack (most recent call first):
  cmake_install.cmake:121 (include)
```

This PR fixes the issue.