### PR TITLE
Changed the param robot_description to be named relatively.

### DIFF
--- a/include/dynamixel_control_hw/hardware_interface.hpp
+++ b/include/dynamixel_control_hw/hardware_interface.hpp
@@ -527,7 +527,7 @@ namespace dynamixel {
         // Get joint limits from the URDF or the parameter server
         // ------------------------------------------------------
 
-        std::string urdf_param_name("/robot_description");
+        std::string urdf_param_name("robot_description");
         // TODO: document this feature
         if (robot_hw_nh.hasParam("urdf_param_name"))
             robot_hw_nh.getParam("urdf_param_name", urdf_param_name);


### PR DESCRIPTION
By naming the param "robot_description" instead of "/robot_description" it is possible to use namespaces when launching this hardware interface. In a multi-robot scenario it is then possible to have one "{namespace}/robot_state_publisher" node for each robot.