### PR TITLE
change read mmethod with bulk method and model abstraction

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,8 +4,8 @@
   <version>0.1.0</version>
   <description>An interface to the Dynamixel actuators for ROS control</description>
 
-  <maintainer email="dorian.goepp@inria.fr">Dorian Goepp</maintainer>
-
+  <maintainer email="pierre.desreumaux@inria.fr">Pierre Desreumaux</maintainer>
+  <author>Dorian Goepp</author>
   <license>CeCILL</license>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Hey! Is this working?. I am trying catkin_make on the devel branch but get this:

`[ 16%] Building CXX object dynamixel_control_hw/CMakeFiles/dynamixel_hw.dir/src/hardware_interface.cpp.o
[ 33%] Building CXX object dynamixel_control_hw/CMakeFiles/dynamixel_control_p1.dir/src/dynamixel_control.cpp.o
[ 50%] Building CXX object dynamixel_control_hw/CMakeFiles/dynamixel_control_p2.dir/src/dynamixel_control.cpp.o
In file included from /home/rf/dynamixel_ws/src/dynamixel_control_hw/src/hardware_interface.cpp:2:0:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp: In instantiation of ‘void dynamixel::DynamixelHardwareInterface<Protocol>::read(const ros::Time&, const ros::Duration&) [with Protocol = dynamixel::protocols::Protocol1]’:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/src/hardware_interface.cpp:10:1:   required from here
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp:284:52: error: ‘using element_type = class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol1> {aka class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol1>}’ has no member named ‘bulk_read_position_angle’; did you mean ‘set_goal_position_angle’?
             _dynamixel_controller.send(_servos[0]->bulk_read_position_angle(_ids_vector));
                                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
                                        set_goal_position_angle
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp: In instantiation of ‘void dynamixel::DynamixelHardwareInterface<Protocol>::read(const ros::Time&, const ros::Duration&) [with Protocol = dynamixel::protocols::Protocol2]’:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/src/hardware_interface.cpp:10:1:   required from here
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp:284:52: error: ‘using element_type = class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol2> {aka class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol2>}’ has no member named ‘bulk_read_position_angle’; did you mean ‘set_goal_position_angle’?
             _dynamixel_controller.send(_servos[0]->bulk_read_position_angle(_ids_vector));
                                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
                                        set_goal_position_angle
In file included from /home/rf/dynamixel_ws/src/dynamixel_control_hw/src/dynamixel_control.cpp:38:0:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp: In instantiation of ‘void dynamixel::DynamixelHardwareInterface<Protocol>::read(const ros::Time&, const ros::Duration&) [with Protocol = dynamixel::protocols::Protocol2]’:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp:260:13:   required from ‘bool dynamixel::DynamixelHardwareInterface<Protocol>::init(ros::NodeHandle&, ros::NodeHandle&) [with Protocol = dynamixel::protocols::Protocol2]’
/home/rf/dynamixel_ws/src/dynamixel_control_hw/src/dynamixel_control.cpp:71:53:   required from here
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp:284:52: error: ‘using element_type = class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol2> {aka class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol2>}’ has no member named ‘bulk_read_position_angle’; did you mean ‘set_goal_position_angle’?
             _dynamixel_controller.send(_servos[0]->bulk_read_position_angle(_ids_vector));
                                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
                                        set_goal_position_angle
In file included from /home/rf/dynamixel_ws/src/dynamixel_control_hw/src/dynamixel_control.cpp:38:0:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp: In instantiation of ‘void dynamixel::DynamixelHardwareInterface<Protocol>::read(const ros::Time&, const ros::Duration&) [with Protocol = dynamixel::protocols::Protocol1]’:
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp:260:13:   required from ‘bool dynamixel::DynamixelHardwareInterface<Protocol>::init(ros::NodeHandle&, ros::NodeHandle&) [with Protocol = dynamixel::protocols::Protocol1]’
/home/rf/dynamixel_ws/src/dynamixel_control_hw/src/dynamixel_control.cpp:71:53:   required from here
/home/rf/dynamixel_ws/src/dynamixel_control_hw/include/dynamixel_control_hw/hardware_interface.hpp:284:52: error: ‘using element_type = class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol1> {aka class dynamixel::servos::BaseServo<dynamixel::protocols::Protocol1>}’ has no member named ‘bulk_read_position_angle’; did you mean ‘set_goal_position_angle’?
             _dynamixel_controller.send(_servos[0]->bulk_read_position_angle(_ids_vector));
                                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
                                        set_goal_position_angle
dynamixel_control_hw/CMakeFiles/dynamixel_hw.dir/build.make:62: recipe for target 'dynamixel_control_hw/CMakeFiles/dynamixel_hw.dir/src/hardware_interface.cpp.o' failed
make[2]: *** [dynamixel_control_hw/CMakeFiles/dynamixel_hw.dir/src/hardware_interface.cpp.o] Error 1
CMakeFiles/Makefile2:454: recipe for target 'dynamixel_control_hw/CMakeFiles/dynamixel_hw.dir/all' failed
make[1]: *** [dynamixel_control_hw/CMakeFiles/dynamixel_hw.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
dynamixel_control_hw/CMakeFiles/dynamixel_control_p2.dir/build.make:62: recipe for target 'dynamixel_control_hw/CMakeFiles/dynamixel_control_p2.dir/src/dynamixel_control.cpp.o' failed
make[2]: *** [dynamixel_control_hw/CMakeFiles/dynamixel_control_p2.dir/src/dynamixel_control.cpp.o] Error 1
CMakeFiles/Makefile2:491: recipe for target 'dynamixel_control_hw/CMakeFiles/dynamixel_control_p2.dir/all' failed
make[1]: *** [dynamixel_control_hw/CMakeFiles/dynamixel_control_p2.dir/all] Error 2
dynamixel_control_hw/CMakeFiles/dynamixel_control_p1.dir/build.make:62: recipe for target 'dynamixel_control_hw/CMakeFiles/dynamixel_control_p1.dir/src/dynamixel_control.cpp.o' failed
make[2]: *** [dynamixel_control_hw/CMakeFiles/dynamixel_control_p1.dir/src/dynamixel_control.cpp.o] Error 1
CMakeFiles/Makefile2:528: recipe for target 'dynamixel_control_hw/CMakeFiles/dynamixel_control_p1.dir/all' failed
make[1]: *** [dynamixel_control_hw/CMakeFiles/dynamixel_control_p1.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
Invoking "make -j4 -l4" failed
`

Any suggestions?